### PR TITLE
Allow reporting pre-releases from github

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,11 @@ func main() {
 						Value:  "rancher-sandbox/os2",
 						Usage:  "Github repository to scan releases against",
 					},
+					&cli.BoolFlag{
+						Name:   "pre-releases",
+						Usage:  "Enable pre-releases in the releases scan",
+						EnvVar: "PRE_RELEASES",
+					},
 				},
 				Action: func(c *cli.Context) error {
 					outFile := c.String("output-file")
@@ -87,6 +92,7 @@ func main() {
 						github.WithVersionNamePrefix(c.String("version-name-prefix")),
 						github.WithVersionNameSuffix(c.String("version-name-suffix")),
 						github.WithBaseImage(c.String("image-prefix")),
+						github.WithPreReleases(c.Bool("pre-releases")),
 					)
 
 					if err != nil {

--- a/pkg/discovery/type/github/github.go
+++ b/pkg/discovery/type/github/github.go
@@ -33,15 +33,15 @@ import (
 )
 
 type githubOptions struct {
-	versionNamePrefix string
-	versionNameSuffix string
-	versionSuffix     string
-	versionPrefix     string
-	baseImage         string
-	githubToken       string
-	repository        string
+	versionNamePrefix  string
+	versionNameSuffix  string
+	versionSuffix      string
+	versionPrefix      string
+	baseImage          string
+	githubToken        string
+	repository         string
 	includePreReleases bool
-	ctx               context.Context
+	ctx                context.Context
 }
 
 type githubSetting func(g *githubOptions) error
@@ -187,7 +187,7 @@ func (f *releaseFinder) Discovery() (res []*provv1.ManagedOSVersion, err error) 
 	rels, err := f.findAll(f.opts.repository)
 	for _, r := range rels {
 
-    // skip pre-releases unless we explicitly include them
+		// skip pre-releases unless we explicitly include them
 		if *r.Prerelease && !f.opts.includePreReleases {
 			continue
 		}

--- a/pkg/discovery/type/github/github_test.go
+++ b/pkg/discovery/type/github/github_test.go
@@ -44,6 +44,38 @@ var _ = Describe("github discovery", func() {
 			Expect(res[0].Spec.Metadata.Data).To(HaveKey("upgradeImage"))
 		})
 
+		It("includes no pre-releases by default", func() {
+			rf, err := NewReleaseFinder(WithRepository("rancher-sandbox/upgradechannel-discovery-test-repo"))
+			Expect(err).ToNot(HaveOccurred())
+
+			res, err := rf.Discovery()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(res) > 0).To(BeTrue())
+
+			Expect(res[0].ObjectMeta.Name).ToNot(BeEmpty())
+			Expect(res[0].Spec.Metadata.Data).To(HaveKey("upgradeImage"))
+			for _, release := range res {
+				Expect(release.Name).ToNot(ContainSubstring("rc1"))
+			}
+		})
+
+		It("includes pre-releases if set", func() {
+			rf, err := NewReleaseFinder(WithRepository("rancher-sandbox/upgradechannel-discovery-test-repo"), WithPreReleases(true))
+			Expect(err).ToNot(HaveOccurred())
+
+			res, err := rf.Discovery()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(res) > 0).To(BeTrue())
+
+			Expect(res[0].ObjectMeta.Name).ToNot(BeEmpty())
+			Expect(res[0].Spec.Metadata.Data).To(HaveKey("upgradeImage"))
+			var versions []string
+			for _, release := range res {
+				versions = append(versions, release.Name)
+			}
+			Expect(versions).Should(ContainElement(ContainSubstring("rc1")))
+		})
+
 		It("manipulates releases results", func() {
 			rf, err := NewReleaseFinder(
 				WithRepository("rancher-sandbox/os2"),


### PR DESCRIPTION
By defautl we should not report pre-releases marked as such in github.
Adds an option to enable pre-releases

Fixes #2 

Signed-off-by: Itxaka <igarcia@suse.com>