### PR TITLE
tests: Add upgrade tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,17 +32,19 @@ replace (
 )
 
 require (
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220407145032-98e4e6e3302b
-	github.com/rancher-sandbox/rancheros-operator v0.1.0-alpha24
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220420071633-4d090487a09f
+	github.com/rancher-sandbox/rancheros-operator v0.1.0
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210927195558-4aaa778d23dd
+	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210929162341-5e6e996d9486
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.5
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a
+	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 )

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,7 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alessio/shellescape v1.2.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -171,6 +172,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -347,6 +349,7 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
+github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -358,6 +361,7 @@ github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4u
 github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
@@ -432,7 +436,6 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/flect v0.2.2/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
@@ -556,7 +559,6 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=
@@ -708,6 +710,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
@@ -741,6 +744,7 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/maruel/panicparse v0.0.0-20171209025017-c0182c169410/go.mod h1:nty42YY5QByNC5MM7q/nj938VbgPU7avs45z6NClpxI=
 github.com/maruel/ut v1.0.0/go.mod h1:I68ffiAt5qre9obEVTy7S2/fj2dJku2NYLvzPuY0gqE=
+github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/matryer/moq v0.0.0-20200607124540-4638a53893e6/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
@@ -817,7 +821,6 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc/go.mod h1:62PewwiQTlm/7Rj+cxVYqZvDIUc+JjZq6GHAC1fsObQ=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
@@ -950,12 +953,11 @@ github.com/pseudomuto/protoc-gen-doc v1.5.0/go.mod h1:exDTOVwqpp30eV/EDPFLZy3Pwr
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220407110407-bb1edfe6bb21/go.mod h1:tBG6E0pF89pslQvva2lKhL/6ShpqAkjwFhdUfevTR6o=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220407145032-98e4e6e3302b h1:Qiuk6Mac457YLNgvlW2dAa5LWxMKWVYihouqDXessZk=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220407145032-98e4e6e3302b/go.mod h1:tBG6E0pF89pslQvva2lKhL/6ShpqAkjwFhdUfevTR6o=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220420071633-4d090487a09f h1:uK8GhwkyGVreyMlgG4eMesj6Iz0eIyLVpRmB6SJjPMA=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220420071633-4d090487a09f/go.mod h1:bbNiiDprIZSIzNmWvyQ+ro6N39bnyNiEGdgiD9vAQM0=
 github.com/rancher-sandbox/go-tpm v0.0.0-20220217133323-a7b15ad1f8f7/go.mod h1:cUw+h4wm01VdavMOjUMVQ5m/b2oiOjZ7gweI8AlybO4=
-github.com/rancher-sandbox/rancheros-operator v0.1.0-alpha24 h1:jjKk2ldYt0vYU12tWcPth5a10VO4jEqjVfx6gbqGnTk=
-github.com/rancher-sandbox/rancheros-operator v0.1.0-alpha24/go.mod h1:0c/AQf5Zj5XpIx6FyAI5ILMmxL3RByBd7uqg8Wl6A6o=
+github.com/rancher-sandbox/rancheros-operator v0.1.0 h1:crkKsG+X1xS5o0+A7KQ/tJfiepeABIOudZ9EmxCAmrA=
+github.com/rancher-sandbox/rancheros-operator v0.1.0/go.mod h1:dSoPliwU2dJAl7v8GbTL9LnEfvRLKd2GqGj/oZNkXkA=
 github.com/rancher/aks-operator v1.0.2/go.mod h1:Nafxvj+HQOMXb418Oj6eFVOUf0fnq8e4RBqi9S+Q5WQ=
 github.com/rancher/apiserver v0.0.0-20210922180056-297b6df8d714/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/dynamiclistener v0.2.1-0.20200714201033-9c1939da3af9/go.mod h1:qr0QfhwzcVCR+Ao9WyfnE+jmOpfEAdRhXtNOZGJ3nCQ=
@@ -1478,6 +1480,7 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1580,7 +1583,6 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1755,8 +1757,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=

--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Discovery e2e tests", func() {
 					"outputFile": "/output/data", // This defaults to /data/output
 					"args":       []string{"github"},
 				},
+				nil,
 			)
 			defer k.Delete("managedosversionchannel", "-n", "fleet-default", "testchannel")
 
@@ -90,6 +91,7 @@ var _ = Describe("Discovery e2e tests", func() {
 					"command": []string{"/usr/bin/upgradechannel-discovery"},
 					"args":    []string{"github"},
 				},
+				nil,
 			)
 			defer k.Delete("managedosversionchannel", "-n", "fleet-default", "testchannel")
 
@@ -135,6 +137,7 @@ var _ = Describe("Discovery e2e tests", func() {
 					"command": []string{"/usr/bin/upgradechannel-discovery"},
 					"args":    []string{"git"},
 				},
+				nil,
 			)
 			defer k.Delete("managedosversionchannel", "-n", "fleet-default", "testchannel3")
 

--- a/tests/e2e/upgrades_test.go
+++ b/tests/e2e/upgrades_test.go
@@ -1,0 +1,375 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	kubectl "github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+
+	"github.com/rancher-sandbox/rancheros-operator/tests/catalog"
+)
+
+const cattleNamespace = "cattle-system"
+const fleetNamespace = "fleet-local"
+
+func getPlan(s string) (up *upgradev1.Plan, err error) {
+	up = &upgradev1.Plan{}
+	err = kubectl.GetObject(s, cattleNamespace, "plan", up)
+	return
+}
+
+func waitTestChannelPopulate(k *kubectl.Kubectl, mr *catalog.ManagedOSVersionChannel, name string, image, version string) {
+	EventuallyWithOffset(1, func() error {
+		return k.ApplyYAML(fleetNamespace, name, mr)
+	}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
+
+	EventuallyWithOffset(1, func() string {
+		r, err := kubectl.GetData(fleetNamespace, "ManagedOSVersion", version, `jsonpath={.spec.metadata.upgradeImage}`)
+		if err != nil {
+			fmt.Println(err)
+		}
+		return string(r)
+	}, 6*time.Minute, 2*time.Second).Should(
+		Equal(image),
+	)
+}
+
+func upgradePod(k *kubectl.Kubectl) string {
+	pods, err := k.GetPodNames(cattleNamespace, "upgrade.cattle.io/controller=system-upgrade-controller")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	podName := ""
+	for _, p := range pods {
+		if strings.Contains(p, "apply-os-upgrader") {
+			podName = p
+		}
+	}
+	return podName
+}
+
+func checkUpgradePod(k *kubectl.Kubectl, env, image, command, args, mm types.GomegaMatcher) {
+	// Wait for the upgrade pod to appear
+	k.EventuallyPodMatch(
+		cattleNamespace,
+		"upgrade.cattle.io/controller=system-upgrade-controller",
+		3*time.Minute, 2*time.Second,
+		ContainElement(ContainSubstring("apply-os-upgrader-on-")),
+	)
+
+	podName := upgradePod(k)
+
+	pod := &corev1.Pod{}
+	err := kubectl.GetObject(podName, cattleNamespace, "pods", pod)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	container := pod.Spec.Containers[0]
+
+	envs := []string{}
+	for _, e := range container.Env {
+		envs = append(envs, fmt.Sprintf("%s=%s", e.Name, e.Value))
+	}
+	mounts := []string{}
+	for _, e := range container.VolumeMounts {
+		mounts = append(mounts, fmt.Sprintf("%s=%s", e.Name, e.MountPath))
+	}
+	ExpectWithOffset(1, container.Name).To(Equal("upgrade"))
+	ExpectWithOffset(1, envs).To(env)
+	ExpectWithOffset(1, container.Image).To(image)
+	ExpectWithOffset(1, container.Command).To(command)
+	ExpectWithOffset(1, container.Args).To(args)
+	ExpectWithOffset(1, mounts).To(mm)
+}
+
+var _ = Describe("ManagedOSImage e2e tests", func() {
+	k := kubectl.New()
+
+	Context("Using ManagedOSVersion reference", func() {
+		osImage := "update-osversion"
+		osVersion := "osversion"
+		AfterEach(func() {
+			k.Delete("managedosimage", "-n", fleetNamespace, osImage)
+			k.Delete("managedosversion", "-n", fleetNamespace, osVersion)
+
+			// Plans do not successfully apply, so nodes stays in cordoned state.
+			// uncordon them so tests will keep running
+			nodeName, err := kubectl.Run("get", "nodes", "-o", "jsonpath='{.items[0].metadata.name}'")
+			Expect(err).ToNot(HaveOccurred())
+			kubectl.Run("uncordon", nodeName)
+
+			k.Delete("jobs", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("plans", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("bundles", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("managedosversionchannel", "--all", "--wait", "-n", fleetNamespace)
+
+			// delete dangling upgrade pods
+			EventuallyWithOffset(1, func() []string {
+				pods, err := k.GetPodNames(cattleNamespace, "upgrade.cattle.io/controller=system-upgrade-controller")
+				if err != nil {
+					fmt.Println(err)
+				}
+				fmt.Println(pods)
+
+				applyPods := []string{}
+				for _, p := range pods {
+					if !strings.HasPrefix(p, "system-upgrade-controller") {
+						applyPods = append(applyPods, p)
+					}
+
+					if strings.Contains(p, "apply-os-upgrader") {
+						By("deleting " + p)
+						k.Delete("pod", "-n", cattleNamespace, "--wait", "--force", p)
+						err = k.WaitForPodDelete(cattleNamespace, p)
+						Expect(err).ToNot(HaveOccurred())
+					}
+				}
+
+				return applyPods
+			}, 3*time.Minute, 2*time.Second).Should(Equal([]string{}))
+		})
+
+		createsCorrectPlan := func(meta map[string]interface{}, c *catalog.ContainerSpec, m types.GomegaMatcher) {
+			ov := catalog.NewManagedOSVersion(
+				osVersion, "v1.0", "0.0.0",
+				meta,
+				c,
+			)
+
+			EventuallyWithOffset(1, func() error {
+				return k.ApplyYAML(fleetNamespace, osVersion, ov)
+			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
+
+			ui := catalog.NewManagedOSImage(
+				osImage,
+				[]map[string]interface{}{},
+				"",
+				osVersion,
+			)
+
+			EventuallyWithOffset(1, func() error {
+				return k.ApplyYAML(fleetNamespace, osImage, ui)
+			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
+
+			EventuallyWithOffset(1, func() string {
+				r, err := kubectl.GetData(fleetNamespace, "bundle", "mos-update-osversion", `jsonpath={.spec.resources[*].content}`)
+				if err != nil {
+					fmt.Println(err)
+				}
+				return string(r)
+			}, 1*time.Minute, 2*time.Second).Should(
+				m,
+			)
+		}
+
+		It("tries to apply a plan", func() {
+			By("creating a new ManagedOSImage referencing a ManagedOSVersion")
+
+			createsCorrectPlan(map[string]interface{}{"upgradeImage": "registry.com/repository/image:v1.0", "robin": "batman"}, nil,
+				And(
+					ContainSubstring(`"version":"v1.0"`),
+					ContainSubstring(`"image":"registry.com/repository/image"`),
+					ContainSubstring(`"command":["/usr/sbin/suc-upgrade"]`),
+					ContainSubstring(`"name":"METADATA_ROBIN","value":"batman"`),
+				),
+			)
+
+			Eventually(func() string {
+				up, err := getPlan("os-upgrader")
+				if err == nil {
+					return up.Spec.Version
+				} else {
+					fmt.Println(err)
+				}
+				return ""
+			}, 1*time.Minute, 2*time.Second).Should(Equal("v1.0"))
+
+			plan, err := getPlan("os-upgrader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(plan.Spec.Upgrade.Image).To(Equal("registry.com/repository/image"))
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_ROBIN=batman"),
+					ContainElement("METADATA_UPGRADEIMAGE=registry.com/repository/image:v1.0"),
+				),
+				Equal("registry.com/repository/image:v1.0"),
+				Equal([]string{"/usr/sbin/suc-upgrade"}),
+				BeNil(),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+		})
+
+		It("applies an os-upgrade from a channel", func() {
+			mr := catalog.NewManagedOSVersionChannel(
+				"testchannel3",
+				"custom",
+				map[string]interface{}{
+					"image": testImage,
+					"envs": []map[string]string{
+						{
+							"name":  "REPOSITORY",
+							"value": "https://github.com/rancher-sandbox/upgradechannel-discovery-test-repo",
+						},
+					},
+					"command": []string{"/usr/bin/upgradechannel-discovery"},
+					"args":    []string{"git"},
+				},
+				nil,
+			)
+			defer k.Delete("managedosversionchannel", "-n", fleetNamespace, "testchannel3")
+
+			waitTestChannelPopulate(k, mr, "testchannel3", "foo/bar:v0.1.0-beta1", "v0.1.0-beta1")
+
+			err := k.ApplyYAML(fleetNamespace, osImage, catalog.NewManagedOSImage(
+				osImage,
+				[]map[string]interface{}{},
+				"",
+				"v0.1.0-beta1",
+			))
+			Expect(err).ToNot(HaveOccurred())
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_UPGRADEIMAGE=foo/bar:v0.1.0-beta1"),
+				),
+				Equal("foo/bar:v0.1.0-beta1"),
+				Equal([]string{"/usr/sbin/suc-upgrade"}),
+				BeNil(),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+		})
+
+		It("overwrites default container spec from a channel", func() {
+			mr := catalog.NewManagedOSVersionChannel(
+				"testchannel4",
+				"custom",
+				map[string]interface{}{
+					"image": testImage,
+					"envs": []map[string]string{
+						{
+							"name":  "REPOSITORY",
+							"value": "https://github.com/rancher-sandbox/upgradechannel-discovery-test-repo",
+						},
+					},
+					"command": []string{"/usr/bin/upgradechannel-discovery"},
+					"args":    []string{"git"},
+				},
+				&catalog.ContainerSpec{
+					Image:   "Foobarz",
+					Command: []string{"foo"},
+					Args:    []string{"baz"},
+				},
+			)
+			defer k.Delete("managedosversionchannel", "-n", fleetNamespace, "testchannel4")
+
+			waitTestChannelPopulate(k, mr, "testchannel4", "foo/bar:v0.1.0-beta1", "v0.1.0-beta1")
+
+			err := k.ApplyYAML(fleetNamespace, osImage, catalog.NewManagedOSImage(
+				osImage,
+				[]map[string]interface{}{},
+				"",
+				"v0.1.0-beta1",
+			))
+			Expect(err).ToNot(HaveOccurred())
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_UPGRADEIMAGE=foo/bar:v0.1.0-beta1"),
+				),
+				Equal("Foobarz"),
+				Equal([]string{"foo"}),
+				Equal([]string{"baz"}),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+		})
+
+		It("tries to apply an upgrade", func() {
+			mr := catalog.NewManagedOSVersionChannel(
+				"testchannel5",
+				"custom",
+				map[string]interface{}{
+					"image": testImage,
+					"envs": []map[string]string{
+						{
+							"name":  "REPOSITORY",
+							"value": "rancher-sandbox/os2",
+						},
+						{
+							"name":  "REPOSITORY",
+							"value": "rancher-sandbox/os2",
+						},
+						{
+							"name":  "IMAGE_PREFIX",
+							"value": "quay.io/costoolkit/os2",
+						},
+						{
+							"name":  "VERSION_SUFFIX",
+							"value": "-amd64",
+						},
+					},
+					"command": []string{"/usr/bin/upgradechannel-discovery"},
+					"args":    []string{"github"},
+				},
+				nil,
+			)
+			defer k.Delete("managedosversionchannel", "-n", fleetNamespace, "testchannel5")
+
+			waitTestChannelPopulate(k, mr, "testchannel5", "quay.io/costoolkit/os2:v0.1.0-alpha22-amd64", "v0.1.0-alpha22-amd64")
+
+			err := k.ApplyYAML(fleetNamespace, osImage,
+				catalog.NewManagedOSImage(osImage, []map[string]interface{}{}, "", "v0.1.0-alpha22-amd64"))
+			Expect(err).ToNot(HaveOccurred())
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_UPGRADEIMAGE=quay.io/costoolkit/os2:v0.1.0-alpha22-amd64"),
+				),
+				Equal("quay.io/costoolkit/os2:v0.1.0-alpha22-amd64"),
+				Equal([]string{"/usr/sbin/suc-upgrade"}),
+				BeNil(),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+
+			Eventually(func() string {
+				podName := upgradePod(k)
+				str, _ := kubectl.Run("logs", "-n", cattleNamespace, podName)
+				fmt.Println(str)
+				return str
+			}, 5*time.Minute, 2*time.Second).Should(
+				And(
+					ContainSubstring("Starting elemental version"),
+					ContainSubstring("Could not find device for COS_RECOVERY label: no device found"),
+				))
+		})
+	})
+})


### PR DESCRIPTION
This PR is porting and adapting slightly upgrade tests from rancheros-operator to test specific upgradechannel-discovery versions. Besides, it is a good testbed to keep in place to gate and tests against the ros-operator bits that connects the two projects together.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>