### PR TITLE
Revert "Update docker.yml"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,7 @@ jobs:
             quay.io/costoolkit/upgradechannel-discovery
           tags: |
             type=semver,pattern=v{{version}}
+            type=sha,format=short,prefix=${{ steps.export_tag.outputs.tag }}-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Reverts rancher-sandbox/upgradechannel-discovery#10

I can see on the docker stuff that it pushed them correctly, so no need for that, its nice to have the TAG+latest+TAG-GIT all in once. Not sure why it was not working before